### PR TITLE
Add configurable softlog option

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,8 @@
         "Username": "SWGAccount",
         "Password": "SWGPassword",
         "Character": "Discord",
-        "ChatRoom": "Genchat"
+        "ChatRoom": "Genchat",
+        "SoftLogInterval": null
     },
     "Discord": {
         "BotName": "RoC-Bot",

--- a/discordbot.js
+++ b/discordbot.js
@@ -3,9 +3,10 @@ const SWG = require('./swgclient');
 const config = require('./config');
 SWG.login(config.SWG);
 
-var client, server, notif, chat, notifRole;
+var client, server, notif, chat, notifRole, softLogInterval;
 function discordBot() {
     client = new Discord.Client();
+    softLogInterval = config.SWG.SoftLogInterval;
 
     client.on('message', message => {
         if (message.content.startsWith('!server')) {
@@ -56,6 +57,7 @@ SWG.serverUp = function() {
 
 SWG.reconnected = function() {
     if (chat) chat.send("chat bot reconnected");
+    if (softLogInterval) SWG.queueSoftLog();
 }
 
 SWG.recvChat = function(message, player) {
@@ -67,6 +69,14 @@ SWG.recvChat = function(message, player) {
 SWG.recvTell = function(from, message) {
     console.log("received tell from: " + from + ": " + message);
     if (from != config.SWG.Character) SWG.sendTell(from, "Hi!");
+}
+
+SWG.queueSoftLog = function() {
+    setTimeout(SWG.softLog, softLogInterval);
+}
+
+SWG.softLog = function() {
+    if (chat) chat.send("chat bot soft logging").then(() => process.exit(0));
 }
 
 setInterval(() => SWG.sendTell(config.SWG.Character, "ping"), 30000);

--- a/swgclient.js
+++ b/swgclient.js
@@ -17,6 +17,8 @@ module.exports.recvChat = function(message, player) {}
 module.exports.serverDown = function() {}
 module.exports.serverUp = function() {}
 module.exports.reconnected = function() {}
+module.exports.queueSoftLog = function() {}
+module.exports.softLog = function() {}
 module.exports.sendTell = function(player, message) {
     if (!module.exports.isConnected) return;
     console.log("sending tell to: " + player + ": " + message);


### PR DESCRIPTION
- Characters can de-sync if not in an instanced area
  + For example, the new character tutorial zone
- In some cases, this isn't feasible
  + Syncing "GuildChat" requires the character to be in the guild
  + To join the guild, the character must leave the starting zone
- Solution: Add a configurable "SoftLogInterval" option
  + A valid value will be a positive integer
  + The integer represents a milliseconds delay to exit the process
  + The exited process would need to be picked up by the daemon
    * `forever` is a suggested option
    * `pm2` is another solid option
  + To opt-out of soft logging:
    * Exclude the property altogether, or
    * Set the property to a falsey value (e.g. `null`, `false`)