### PR TITLE
[Added] Missing NetStatusRequest packet.

### DIFF
--- a/SOEProtocol.js
+++ b/SOEProtocol.js
@@ -196,6 +196,13 @@ EncodeSWGPacket["Ack"] = function(data) {
     return Encrypt(buf);
 }
 
+EncodeSWGPacket["NetStatusRequest"] = function(data) {
+    var buf = new Buffer(4);
+    buf.writeUInt16BE(0x7, 0);
+    buf.writeUInt16BE(0, 2);
+    return Encrypt(buf);
+}
+
 EncodeSWGPacket["SessionRequest"] = function() {
     var buf = new Buffer(14);
     buf.writeUInt16BE(1, 0);

--- a/swgclient.js
+++ b/swgclient.js
@@ -168,6 +168,7 @@ setInterval(() => {
     socket.send(buf, server.PingPort, server.Address);
 }, 1000);
 
-
-
-
+setInterval(() => {
+    if (!module.exports.isConnected) return;
+	send("NetStatusRequest");
+}, 40000);


### PR DESCRIPTION
Core3 expects a NetStatusRequest from the client every so often. If the server does not get it, the bot is disconnected.

This resolves: https://github.com/dpwhittaker/swg-discord-bot/issues/3